### PR TITLE
return text in __str__ methods for py2/3

### DIFF
--- a/aldryn_mailchimp/models.py
+++ b/aldryn_mailchimp/models.py
@@ -19,7 +19,7 @@ class SubscriptionPlugin(CMSPlugin):
             'Save the user\'s language based on the page language'))
 
     def __str__(self):
-        return unicode(self.list_id)
+        return self.list_id
 
 
 class CampaignManager(models.Manager):
@@ -40,7 +40,7 @@ class Category(Sortable):
         verbose_name_plural = _('Categories')
 
     def __str__(self):
-        return unicode(self.name)
+        return self.name
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
A couple of **str** methods (decorated with @python_2_unicode_compatible
) used unicode(), breaking in python3. My understanding is that returning text is the right move for python2/3 compatibility.
