### PR TITLE
Python 3, Django-CMS 3.3, Mailchimp API V3.0 (clean PR)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,17 +7,41 @@ Aldryn MailChimp is the easiest way to integrate MailChimp into
 
 With Aldryn MailChimp you can:
 
-- Allow users to subscribe to mailing lists
-- Displays existing campaigns
+- Allow users to subscribe to mailing lists (CMS Plugin)
+- Displays existing campaigns (App Hook + CMS Plugins)
 
 To activate MailChimp integration:
 
-- provide an ``API Key`` while installing an app
-- create an CMS page for hooking the app (navigate to
-  ``Advanced Settings -> Application`` on CMS edit page)
+- provide an Mailchimp ``User Name`` and ``API Key`` while installing the Aldryn app
+- add the Mailchimp subscription form to your CMS page placeholder
+- create an CMS page for hooking the app for displaying existing campaigns (optional)
 
-When all above is done, you can add MailChimp integration plugins to
-placeholders.
+Notice:
+Grab `API Key` from your mailchimp account (Account > Extra > Api Keys). And
+`User Name` is the one you use to login on the website and is optional.
+
+===========
+CMS Plugins
+===========
+
+- Submission (form with email field form)
+
+=============
+App Hook Page
+=============
+
+- Campaign Archives (List campaign archives)
+- Selected Campaign (Show html or text of selected campaign)
+
+++++++++++++
+Get Campaign
+++++++++++++
+
+Use the Django management command ``fetch_campaigns`` to retrieve current campaigns::
+
+  $ python manage.py fetch_campaigns
+
+Notice: this command can be run from admin Campaign view action list.
 
 ===============================
 Categories + Automatic Matching
@@ -26,7 +50,7 @@ Categories + Automatic Matching
 Version 0.2.4 introduced categories with automatic matching. You can define
 categories and add keywords to those categories to automatically sort synced
 campaigns into categories. You can define priorities for both campaigns and
-their keywords.
+their keywords. Used in app hook page.
 
 ++++++++
 Matching
@@ -41,7 +65,16 @@ following three:
 - campaign title
 - campaign subject
 - campaign content
+- campaign list name
 
 Once a match is found, the search for the current campaign will be stopped, the
 found category will be assigned to the campaign and the matcher will then
 continue with the next campaign.
+
+=========
+Changelog
+=========
+
+- Base version: 0.3.0
+- Migrated to Python 3.5, plus switch to the Python Mailchimp v3.0 client API
+- django-CMS 3.3+ compatible

--- a/addon.json
+++ b/addon.json
@@ -2,7 +2,6 @@
     "package-name": "aldryn-mailchimp",
     "installed-apps": [
         "adminsortable",
-        "pyrate",
         "aldryn_mailchimp"
     ]
 }

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -3,8 +3,10 @@ from aldryn_client import forms
 
 
 class Form(forms.BaseForm):
+    mailchimp_username = forms.CharField('MailChimp Username', max_length=50)
     mailchimp_api_key = forms.CharField('MailChimp API Key', max_length=50)
 
     def to_settings(self, data, settings):
+        settings['MAILCHIMP_USERNAME'] = data['mailchimp_username']
         settings['MAILCHIMP_API_KEY'] = data['mailchimp_api_key']
         return settings

--- a/aldryn_mailchimp/__init__.py
+++ b/aldryn_mailchimp/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/aldryn_mailchimp/admin.py
+++ b/aldryn_mailchimp/admin.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+
 from django.contrib import admin
+from django.core.management import call_command
 from django.utils.translation import ugettext_lazy as _
 
 from adminsortable.admin import SortableAdmin, SortableTabularInline
@@ -17,31 +19,34 @@ class CategoryAdmin(SortableAdmin):
 
 
 class CampaignAdmin(admin.ModelAdmin):
-    list_display = ('mc_title', 'subject', 'display_name', 'send_time',
-                    'hidden', 'category')
-    search_fields = ('cid', 'subject', 'mc_title', 'display_name',)
+    list_display = ('mc_title', 'display_name', 'list_name',
+                    'list_id', 'send_time', 'hidden', 'category')
+    search_fields = ('cid', 'subject', 'mc_title', 'list_name',
+                     'list_id', 'display_name')
     list_filter = ('hidden', 'category')
     list_editable = ('hidden', )
     readonly_fields = ('cid', 'mc_title', 'subject', 'send_time',
-                       'content_html', 'content_text', 'slug')
+                       'content_html', 'content_text', 'slug',
+                       'list_name', 'list_id',)
+    actions = ['fetch_campaigns']
 
     _fieldsets = (
         (_('MailChimp Info'), {
             'fields': (
-                'cid', 'mc_title', 'subject', 'send_time',
-            )}
-         ),
+                'cid', 'mc_title', 'subject',
+                'send_time',
+                ('list_name', 'list_id'),
+            )}),
         (_('Visibility & Classification'), {
             'fields': (
-                'display_name', 'hidden', 'category',
-            )}
-         ),
+                ('display_name', 'category'),
+                'hidden',
+            )}),
         (_('Content'), {
             'classes': ('collapse', ),
             'fields': (
                 'content_text', 'content_html',
-            )}
-         ),
+            )}),
     )
 
     def get_fieldsets(self, request, obj=None):
@@ -52,6 +57,10 @@ class CampaignAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def fetch_campaigns(self, request, queryset):
+        call_command('fetch_campaigns')
+    fetch_campaigns.short_description = "Fetch campaigns from Mailchimp"
 
 
 admin.site.register(Category, CategoryAdmin)

--- a/aldryn_mailchimp/cms_apps.py
+++ b/aldryn_mailchimp/cms_apps.py
@@ -7,7 +7,9 @@ from cms.apphook_pool import apphook_pool
 
 class CampaignArchive(CMSApp):
     name = _('Campaign Archive')
-    urls = ['aldryn_mailchimp.urls']
+
+    def get_urls(self, page=None, language=None, **kwargs):
+        return['aldryn_mailchimp.urls']
 
 
 apphook_pool.register(CampaignArchive)

--- a/aldryn_mailchimp/cms_plugins.py
+++ b/aldryn_mailchimp/cms_plugins.py
@@ -6,17 +6,23 @@ from django.utils.translation import ugettext_lazy as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
+from .models import (
+    Campaign,
+    SubscriptionPlugin,
+    CampaignArchivePlugin,
+    SelectedCampaignsPlugin
+)
 from .views import SubscriptionView
-from .models import Campaign, SubscriptionPlugin, CampaignArchivePlugin, SelectedCampaignsPlugin
 from .forms import SubscriptionPluginForm
 
 
+@plugin_pool.register_plugin
 class SubscriptionCMSPlugin(CMSPluginBase):
     cache = False
     render_template = 'aldryn_mailchimp/snippets/_subscription.html'
-    name = _('Subscription')
-    model = SubscriptionPlugin
     module = _('MailChimp')
+    name = _('Subscription Form')
+    model = SubscriptionPlugin
 
     def render(self, context, instance, placeholder):
         request = context['request']
@@ -31,15 +37,13 @@ class SubscriptionCMSPlugin(CMSPluginBase):
     def get_plugin_urls(self):
         subscription_view = self.get_subscription_view()
 
-        return patterns('',
-            url(
-                r'^subscribe/$', never_cache(subscription_view),
-                name='aldryn-mailchimp-subscribe'),
+        return patterns('', url(
+            r'^subscribe/$', never_cache(subscription_view),
+            name='aldryn-mailchimp-subscribe'),
         )
 
-plugin_pool.register_plugin(SubscriptionCMSPlugin)
 
-
+@plugin_pool.register_plugin
 class CampaignArchive(CMSPluginBase):
     render_template = 'aldryn_mailchimp/plugins/campaign_archive.html'
     name = _('Campaign Archive')
@@ -55,9 +59,8 @@ class CampaignArchive(CMSPluginBase):
         context['object_list'] = objects
         return context
 
-plugin_pool.register_plugin(CampaignArchive)
 
-
+@plugin_pool.register_plugin
 class SelectedCampaigns(CMSPluginBase):
     render_template = 'aldryn_mailchimp/plugins/selected_campaigns.html'
     name = _('Selected Campaigns')
@@ -65,7 +68,5 @@ class SelectedCampaigns(CMSPluginBase):
     model = SelectedCampaignsPlugin
 
     def render(self, context, instance, placeholder):
-        context['object_list'] = instance.campaigns.objects.all()
+        context['object_list'] = instance.campaigns.all()
         return context
-
-plugin_pool.register_plugin(SelectedCampaigns)

--- a/aldryn_mailchimp/forms.py
+++ b/aldryn_mailchimp/forms.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 class SubscriptionPluginForm(forms.Form):
 
-    email = forms.EmailField(max_length=100, label=_('E-mail'))
+    email = forms.EmailField(max_length=254, label=_('Email'))
+
     plugin_id = forms.CharField(widget=forms.HiddenInput)
     redirect_url = forms.CharField(widget=forms.HiddenInput)

--- a/aldryn_mailchimp/locale/de/LC_MESSAGES/django.po
+++ b/aldryn_mailchimp/locale/de/LC_MESSAGES/django.po
@@ -47,8 +47,8 @@ msgid "Selected Campaigns"
 msgstr "Ausgewählte Kampagnen"
 
 #: forms.py:8
-msgid "E-mail"
-msgstr ""
+msgid "Email"
+msgstr "E-mail"
 
 #: models.py:13
 msgid "List ID"

--- a/aldryn_mailchimp/locale/en/LC_MESSAGES/django.po
+++ b/aldryn_mailchimp/locale/en/LC_MESSAGES/django.po
@@ -46,7 +46,7 @@ msgid "Selected Campaigns"
 msgstr ""
 
 #: forms.py:8
-msgid "E-mail"
+msgid "Email"
 msgstr ""
 
 #: models.py:13

--- a/aldryn_mailchimp/management/commands/fetch_campaigns.py
+++ b/aldryn_mailchimp/management/commands/fetch_campaigns.py
@@ -2,8 +2,9 @@
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.utils.text import slugify
+from django.utils.dateparse import parse_datetime
 
-from pyrate.services import mailchimp
+from mailchimp3 import MailChimp
 
 from ...models import Campaign, Category
 
@@ -17,6 +18,7 @@ class Command(BaseCommand):
         keyword_groups = {
             'name': {},
             'subject': {},
+            'listname': {},
             'content': {},
         }
 
@@ -26,6 +28,8 @@ class Command(BaseCommand):
                     keyword_groups['name'][kw.value.lower()] = kw.category.id
                 if kw.scope_subject:
                     keyword_groups['subject'][kw.value.lower()] = kw.category.id
+                if kw.scope_listname:
+                    keyword_groups['listname'][kw.value.lower()] = kw.category.id
                 if kw.scope_content:
                     keyword_groups['content'][kw.value.lower()] = kw.category.id
         return keyword_groups
@@ -35,6 +39,7 @@ class Command(BaseCommand):
             # kw-group, campaign-attr
             ('name', 'mc_title'),
             ('subject', 'subject'),
+            ('listname', 'list_name'),
             ('content', 'content_text'),
         )
 
@@ -43,7 +48,8 @@ class Command(BaseCommand):
         for kw_group, campaign_attr in attr_list:
             if not category_id:
                 for kw, cat in self.keywords[kw_group].items():
-                    if getattr(campaign, campaign_attr) and kw in getattr(campaign, campaign_attr).lower():
+                    if getattr(campaign, campaign_attr) and \
+                       kw in getattr(campaign, campaign_attr).lower():
                         category_id = cat
                         break
 
@@ -51,24 +57,29 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.keywords = self.fetch_keywords()
-        mc = mailchimp.MailchimpPyrate(settings.MAILCHIMP_API_KEY)
-        response = mc.post('campaigns/list')
-        for each in response['data']:
+        mc = MailChimp(settings.MAILCHIMP_USERNAME, settings.MAILCHIMP_API_KEY)
+        response = mc.campaigns.all(get_all=False)
+
+        for each in response['campaigns']:
             campaign, created = Campaign.objects.get_or_create(cid=each['id'])
-            campaign.send_time = each['send_time']
-            campaign.mc_title = each['title']
-            campaign.subject = each['subject']
-            campaign.slug = slugify(each['subject'])[:50] if each['subject'] else campaign.pk
+            campaign.send_time = parse_datetime(each['send_time'])
+            campaign.mc_title = each['settings']['title']
+            campaign.subject = each['settings']['subject_line']
+            campaign.list_name = each['recipients']['list_name']
+            campaign.list_id = each['recipients']['list_id']
+            campaign.slug = slugify(each['settings']['subject_line'])[:50] \
+                if each['settings']['subject_line'] else campaign.pk
 
             # content
             try:
-                response_content = mc.post('campaigns/content', content={'cid': campaign.cid})
+                response_content = mc.campaigns.content.get(
+                    campaign_id=campaign.cid)
             except Exception as e:
                 print(e)
                 campaign.hidden = True
             else:
-                campaign.content_text = response_content['text']
-                campaign.content_html = response_content['html']
+                campaign.content_text = response_content['plain_text']
+                campaign.content_html = response_content['archive_html']
 
             # match campaign to category (if not set yet)
             if not campaign.category:
@@ -78,4 +89,4 @@ class Command(BaseCommand):
 
             campaign.save()
 
-        print('imported %i campaigns' % len(response['data']))
+        print('Imported {0} campaigns'.format(response['total_items']))

--- a/aldryn_mailchimp/management/commands/fetch_campaigns.py
+++ b/aldryn_mailchimp/management/commands/fetch_campaigns.py
@@ -6,8 +6,8 @@ from django.utils.dateparse import parse_datetime
 
 from mailchimp3 import MailChimp
 
-from aldryn-mailchimp.models import Campaign, Category
-from aldryn-mailchimp.utils import get_list_data
+from aldryn_mailchimp.models import Campaign, Category
+from aldryn_mailchimp.utils import get_list_data
 
 
 class Command(BaseCommand):

--- a/aldryn_mailchimp/migrations/0002_auto_20170927_1455.py
+++ b/aldryn_mailchimp/migrations/0002_auto_20170927_1455.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_mailchimp', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='campaign',
+            name='list_id',
+            field=models.CharField(max_length=50, editable=False, blank=True, null=True, verbose_name='list id'),
+        ),
+        migrations.AddField(
+            model_name='campaign',
+            name='list_name',
+            field=models.CharField(max_length=255, editable=False, blank=True, null=True, verbose_name='list name'),
+        ),
+        migrations.AddField(
+            model_name='keyword',
+            name='scope_listname',
+            field=models.BooleanField(default=True, verbose_name='search in campaign list name'),
+        ),
+        migrations.AddField(
+            model_name='subscriptionplugin',
+            name='optin',
+            field=models.BooleanField(help_text='If select perform double opt-in.', default=True, verbose_name='Double Opt-In'),
+        ),
+        migrations.AlterField(
+            model_name='campaignarchiveplugin',
+            name='categories',
+            field=models.ManyToManyField(verbose_name='filter by category/categories', to='aldryn_mailchimp.Category'),
+        ),
+        migrations.AlterField(
+            model_name='campaignarchiveplugin',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(to='cms.CMSPlugin', auto_created=True, primary_key=True, related_name='aldryn_mailchimp_campaignarchiveplugin', serialize=False, parent_link=True),
+        ),
+        migrations.AlterField(
+            model_name='selectedcampaignsplugin',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(to='cms.CMSPlugin', auto_created=True, primary_key=True, related_name='aldryn_mailchimp_selectedcampaignsplugin', serialize=False, parent_link=True),
+        ),
+        migrations.AlterField(
+            model_name='subscriptionplugin',
+            name='cmsplugin_ptr',
+            field=models.OneToOneField(to='cms.CMSPlugin', auto_created=True, primary_key=True, related_name='aldryn_mailchimp_subscriptionplugin', serialize=False, parent_link=True),
+        ),
+        migrations.AlterField(
+            model_name='subscriptionplugin',
+            name='list_id',
+            field=models.CharField(help_text='ID of the list found in Mailchimp list: Settings > List name and defaults', max_length=20, verbose_name='List ID'),
+        ),
+    ]

--- a/aldryn_mailchimp/templates/aldryn_mailchimp/base.html
+++ b/aldryn_mailchimp/templates/aldryn_mailchimp/base.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends CMS_TEMPLATE %}
 
 {% block content %}
     {% block mailchimp_content %}{% endblock %}

--- a/aldryn_mailchimp/templates/aldryn_mailchimp/campaign_detail.html
+++ b/aldryn_mailchimp/templates/aldryn_mailchimp/campaign_detail.html
@@ -1,5 +1,7 @@
-{% extends "fullwidth.html" %}
+{% extends "aldryn_mailchimp/base.html" %}
 {% load sekizai_tags %}
+
+{# recomended style="border: none; overflow: hidden;" #}
 
 {% block content %}
     {% addtoblock 'js' %}
@@ -13,7 +15,7 @@
     {% if object.content_html %}
         <iframe
             src="{% url 'mailchimp_campaign_detail' pk=object.pk slug=object.slug %}?iframe"
-            width="100%" onload='javascript:resizeIframe(this);'>
+            width="100%" onload="javascript:resizeIframe(this);">
         </iframe>
     {% else %}
         <pre>{{ object.content_text }}</pre>

--- a/aldryn_mailchimp/templates/aldryn_mailchimp/campaign_list.html
+++ b/aldryn_mailchimp/templates/aldryn_mailchimp/campaign_list.html
@@ -1,4 +1,4 @@
-{% extends "fullwidth.html" %}
+{% extends "aldryn_mailchimp/base.html" %}
 
 {% block content %}
     {% include "aldryn_mailchimp/includes/campaign_list.html" %}

--- a/aldryn_mailchimp/templates/aldryn_mailchimp/snippets/_subscription.html
+++ b/aldryn_mailchimp/templates/aldryn_mailchimp/snippets/_subscription.html
@@ -2,6 +2,7 @@
 
 <form class="mailchimp-subscription-form" action="{% url 'admin:aldryn-mailchimp-subscribe' %}" method="POST">
 	{% csrf_token %}
-	{{ form.as_ul }}
-	<input type="submit" value="{% trans 'Subscribe' %}"/>
+	<ul>{{ form.as_ul }}
+	<li><input type="submit" value="{% trans 'Subscribe' %}"/></li>
+	</ul>
 </form>

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,11 @@ from aldryn_mailchimp import __version__
 
 REQUIREMENTS = [
     'django-admin-sortable',
-    'pyrate>=0.5a5',
-    'oauthlib<0.7.0',
+    'mailchimp3>=2.0.9',
 ]
 
 CLASSIFIERS = [
-    'Development Status :: 2 - Pre-Alpha',
+    'Development Status :: 4 - Beta',
     'Environment :: Web Environment',
     'Framework :: Django',
     'Intended Audience :: Developers',
@@ -21,6 +20,7 @@ CLASSIFIERS = [
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3.5',
 ]
 
 setup(


### PR DESCRIPTION
Changes:

- fix for python 3.x compatibility
- use python mailchimp3 in place to pyrate to use V3.0 API
- fix app hook for django-cms >=3.3
- fetch_campaigns: now get campaigns in place of lists
- fetch_campaigns: added in Campaign admin actions
- campaign admin view: added list_name, list_id associated to campaign
- keywords: added list_name to filter auto categories when fetch_campaigns
- complementary info in README
- template fix for Campaign Archive and Selected Campaign plugin template to work with django-cms 3.x
- add optional subscription opt-in
- version incremented to 0.3.1
- pep8 compliant 